### PR TITLE
Add multi-zone support

### DIFF
--- a/modules/fortigate/fgt_asg_with_function/function.tf
+++ b/modules/fortigate/fgt_asg_with_function/function.tf
@@ -9,7 +9,7 @@ resource "google_logging_project_sink" "topic" {
     resource.type="gce_instance" AND
     logName="projects/${var.project}/logs/cloudaudit.googleapis.com%2Factivity" AND
     (protoPayload.methodName:"compute.instances.insert" OR protoPayload.methodName:"compute.instances.delete") AND
-    protoPayload.resourceName:"/zones/${var.zone}/instances/${var.prefix}" AND
+    protoPayload.resourceName=~"/zones/${var.region}-./instances/${var.prefix}" AND
     operation.last=true
   EOT
   unique_writer_identity = true # Use a unique writer

--- a/modules/fortigate/fgt_asg_with_function/function.tf
+++ b/modules/fortigate/fgt_asg_with_function/function.tf
@@ -8,7 +8,7 @@ resource "google_logging_project_sink" "topic" {
   filter                 = <<-EOT
     resource.type="gce_instance" AND
     logName="projects/${var.project}/logs/cloudaudit.googleapis.com%2Factivity" AND
-    (protoPayload.methodName:"compute.instances.insert" OR protoPayload.methodName:"compute.instances.delete") AND
+    (protoPayload.methodName:"compute.instances.insert" OR protoPayload.methodName:"compute.instances.delete" OR protoPayload.methodName:"compute.instances.update") AND
     protoPayload.resourceName=~"/zones/${var.region}-./instances/${var.prefix}" AND
     operation.last=true
   EOT

--- a/modules/fortigate/fgt_asg_with_function/main.tf
+++ b/modules/fortigate/fgt_asg_with_function/main.tf
@@ -85,19 +85,20 @@ resource "google_compute_region_instance_template" "main" {
   }
 }
 
-resource "google_compute_instance_group_manager" "manager" {
-  name               = "${local.prefix}instance-group"
-  base_instance_name = "${local.prefix}group"
+resource "google_compute_region_instance_group_manager" "manager" {
+  name                      = "${local.prefix}instance-group"
+  base_instance_name        = "${local.prefix}group"
+  region                    = var.region
+  distribution_policy_zones = length(var.zones) > 0 ? var.zones : null
   version {
     instance_template = google_compute_region_instance_template.main.self_link
   }
-  zone         = var.zone
 }
 
-resource "google_compute_autoscaler" "autoscaler" {
+resource "google_compute_region_autoscaler" "autoscaler" {
   name   = "${local.prefix}autoscaler"
-  zone   = var.zone
-  target = google_compute_instance_group_manager.manager.id
+  region = var.region
+  target = google_compute_region_instance_group_manager.manager.id
 
   autoscaling_policy {
     max_replicas    = var.autoscaler.max_instances

--- a/modules/fortigate/fgt_asg_with_function/main.tf
+++ b/modules/fortigate/fgt_asg_with_function/main.tf
@@ -1,5 +1,5 @@
 locals {
-  prefix              = "${var.prefix}-"
+  prefix              = var.prefix == "" ? "" : "${var.prefix}-"
   fgt_password        = var.fgt_password == "" ? random_password.fgt_password[0].result : var.fgt_password
   autoscale_psksecret = var.cloud_function.autoscale_psksecret == "" ? random_password.autoscale_psksecret[0].result : var.cloud_function.autoscale_psksecret
 }

--- a/modules/fortigate/fgt_asg_with_function/output.tf
+++ b/modules/fortigate/fgt_asg_with_function/output.tf
@@ -1,5 +1,5 @@
 output "instance_group_id" {
-  value       = google_compute_instance_group_manager.manager.instance_group
+  value       = google_compute_region_instance_group_manager.manager.instance_group
   description = "The full URL of the instance group created by this module."
 }
 

--- a/modules/fortigate/fgt_asg_with_function/variables.tf
+++ b/modules/fortigate/fgt_asg_with_function/variables.tf
@@ -18,9 +18,10 @@ variable "region" {
   description = "Region to deploy VM."
 }
 
-variable "zone" {
-  type        = string
-  description = "Zone to deploy VM."
+variable "zones" {
+  type        = list(string)
+  description = "Preferred zones to deploy VM."
+  default     = []
 }
 
 # FGT vars


### PR DESCRIPTION
For elevated SLA it is recommended to deploy resources across 2 availabilty zones. This PR changes the deployment from zonal to regional.

Additional change to managed instance group enables auto-healing. 